### PR TITLE
Add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # PokeAPI SDK
 
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.0-blue?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![Bun](https://img.shields.io/badge/Bun-1.0-f9f1e1?logo=bun&logoColor=black)](https://bun.sh/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 A comprehensive TypeScript SDK for [PokeAPI](https://pokeapi.co/) built with Bun. This library provides a type-safe, easy-to-use interface for accessing Pokemon data including Pokemon, moves, abilities, berries, locations, and evolution chains.
 
 ## Features


### PR DESCRIPTION
## Summary
- Add TypeScript version badge
- Add Bun runtime badge  
- Add MIT license badge

These badges improve project visibility and provide quick reference information for developers.

## Test plan
- [x] Verify badges render correctly in GitHub README preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)